### PR TITLE
Small fix to specs to get it to run on newer versions of Crystal

### DIFF
--- a/spec/metaphone_spec.cr
+++ b/spec/metaphone_spec.cr
@@ -19,12 +19,12 @@ end
 
 describe "Single Metaphone" do
   it "should metaphone" do
-    YAML.parse(File.read("spec/data/metaphone.yml")).each do |input, expected_output|
+    YAML.parse(File.read("spec/data/metaphone.yml")).as_h.each do |input, expected_output|
       Text::Metaphone.metaphone(input.to_s).should eq expected_output.to_s
     end
   end
 
-  it "should test_junk" do 
+  it "should test_junk" do
     Text::Metaphone.metaphone("foobar").should eq Text::Metaphone.metaphone("%^@#$^f%^&o%^o@b#a@#r%^^&")
     Text::Metaphone.metaphone("foobar", {"buggy"=>"true"}).should eq Text::Metaphone.metaphone("%^@#$^f%^&o%^o@b#a@#r%^^&", {"buggy"=>"true"})
   end

--- a/spec/soundex_spec.cr
+++ b/spec/soundex_spec.cr
@@ -4,7 +4,7 @@ require "yaml"
 describe Text::Soundex do
   it "should test_cases" do
     data = YAML.parse(File.read("spec/data/soundex.yml"))
-    data.each do |input|
+    data.as_h.keys.each do |input|
       input = input.to_s
       expected_output = data[input].to_s
       Text::Soundex.soundex(input).should eq expected_output


### PR DESCRIPTION
Newer versions of Crystal removed YAML::Any#each, so specs weren't running. Should resolve #1 